### PR TITLE
Support Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class policy_engine (
   file { "${::policy_engine_config_dir}/config.yml":
     ensure  => file,
     content => template('policy_engine/policy_config.erb'),
-    mode    => 0440,
+    mode    => '0440',
   }
 
   file { $test_dir:

--- a/manifests/test.pp
+++ b/manifests/test.pp
@@ -26,13 +26,13 @@ define policy_engine::test(
       $tags,
       "${policy_engine::test_dir}/metadata/${name}.yml",
       "${policy_engine::test_dir}/payloads/${name}"),
-    mode    => 0440,
+    mode    => '0440',
   }
 
   file { "${policy_engine::test_dir}/payloads/${name}":
     ensure  => $ensure,
     content => $script,
     source  => $source,
-    mode    => 0550,
+    mode    => '0550',
   }
 }

--- a/templates/policy_config.erb
+++ b/templates/policy_config.erb
@@ -1,2 +1,2 @@
 ---
-test_dir: <%= test_dir %>
+test_dir: <%= @test_dir %>


### PR DESCRIPTION
Previous to this commit, file modes were managed as integers instead of
strings which caused compilation failures in Puppet 4. Further, the
policy_config.erb template didn't use the class instance variable
reference syntax for Puppet class variables.  This commit fixes both
issues