### PR TITLE
Support puppet 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 pkg/
 .DS_Store
+log

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :development do
+  gem 'bundler', '1.10.5'
   gem 'cucumber'
   gem 'beaker-rspec'
   gem 'pry'

--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,5 @@ require 'cucumber'
 require 'cucumber/rake/task'
 
 Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = "features --format pretty"
+    t.cucumber_opts = "features"
 end

--- a/features/nodesets/default.yml
+++ b/features/nodesets/default.yml
@@ -5,10 +5,9 @@ HOSTS:
       - agent
       - default
     platform: el-7-x86_64
-    box:  puppetlabs/centos-7.0-64-nocm
+    box:  puppetlabs/centos-7.0-64-puppet
     hypervisor: vagrant
-    provider: vmware_fusion
-    ip: 10.255.105.95
-    auto_config: false
+    auto_config: true
+    vagrant_memsize: 4096
 CONFIG:
   type: foss

--- a/features/step_definitions/global/when_step.rb
+++ b/features/step_definitions/global/when_step.rb
@@ -11,7 +11,7 @@ end
 When(/^the test is run$/) do
   #Make sure pluginsync as occured
   pluginsync
-  
-  evaluate = shell("facter -p #{@test_name}").stdout.chomp
-  @test_result = eval(evaluate)
+
+  evaluate = shell("facter -p --json #{@test_name}").stdout
+  @test_result = JSON::parse(evaluate)[@test_name]
 end

--- a/features/step_definitions/use_exit_codes_for_determining_pass_fail_step.rb
+++ b/features/step_definitions/use_exit_codes_for_determining_pass_fail_step.rb
@@ -16,7 +16,7 @@ Given(/^the exit code is (\d+) on the node$/) do |exit_code|
   manifest = <<-EOS
   policy_engine::test { "#{@test_name}":
     script => 'echo hello',
-    expected_exit_code => '#{exit_code}',
+    expected_exit_code => #{exit_code},
   }
   EOS
   apply_manifest manifest, {:catch_errors => true}
@@ -25,7 +25,7 @@ end
 Then(/^the exit code should be (\d+)$/) do |exit_code|
   metadata_content = shell("cat #{policy_engine_config['test_dir']}/metadata/#{@test_name}.yml").stdout.chomp
   config = YAML::load(metadata_content)
-  actual_exit_code = begin 
+  actual_exit_code = begin
                        Integer(exit_code)
                      rescue ArgumentError
                        Array(exit_code)

--- a/features/support/cucumber_beaker.rb
+++ b/features/support/cucumber_beaker.rb
@@ -68,8 +68,7 @@ class Cucumber::Beaker
   end
 
   def puppet_module_install_on_all_hosts(opts)
-    puppet_module_install opts
-    pluginsync
+    copy_module_to 'master', :source => opts[:source], :target_module_path => '/etc/puppetlabs/code/modules'
   end
 
   def puppet_installed?
@@ -83,8 +82,12 @@ class Cucumber::Beaker
   end
 
   def install_masters
-    install_package master, 'puppet-server'
-    on master, 'service puppetmaster start'
+    # Obviously this only works on RHEL 7 hosts. This needs to be fixed for more
+    # OSes in the future
+    rhel_7_pkg = 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
+    on master, "sudo rpm -ivh #{rhel_7_pkg}; yum makecache"
+    install_package master, 'puppetserver'
+    on master, 'puppet resource service puppetserver ensure=running'
   end
 
   def set_hosts

--- a/features/write_policy_tests_in_any_language.feature
+++ b/features/write_policy_tests_in_any_language.feature
@@ -4,32 +4,32 @@ Feature: Write policy tests in any language
   so that I don’t have to learn a new language to write policy tests
 
   Scenario: Inline script is wrong on node
-    Given an inline shell script that runs 'ls -l /opt'
+    Given an inline shell script that runs 'ls -l /tmp'
     And a policy test using the inline script is declared
     And the script is 'echo wrong' on the node
     When puppet runs
-    Then the script should be 'ls -l /opt'
+    Then the script should be 'ls -l /tmp'
 
   Scenario: Inline script is correct on node
-    Given an inline shell script that runs 'ls -l /opt'
+    Given an inline shell script that runs 'ls -l /tmp'
     And a policy test using the inline script is declared
-    And the script is 'ls -l /opt' on the node
+    And the script is 'ls -l /tmp' on the node
     When puppet runs
-    Then the script should be 'ls -l /opt'
+    Then the script should be 'ls -l /tmp'
 
   Scenario: Inline script succeeds
-    Given an inline shell script that runs 'ls -l /opt'
+    Given an inline shell script that runs 'ls -l /tmp'
     And a policy test using the inline script is declared
     And the expectation is the script output returns an empty string
     And the policy test exists on the node
-    And the /opt directory is empty
+    And the /tmp directory is empty
     When the test is run
     Then the test should pass
 
   Scenario: Inline script fails
-    Given an inline shell script that runs 'ls -l /opt'
+    Given an inline shell script that runs 'ls -l /tmp'
     And the expectation is the script output returns an empty string
-    And the /opt directory is not empty
+    And the /tmp directory is not empty
     And a policy test using the inline script is declared
     And the policy test exists on the node
     When the test is run

--- a/lib/puppet/parser/functions/policy_engine_test_config.rb
+++ b/lib/puppet/parser/functions/policy_engine_test_config.rb
@@ -4,7 +4,7 @@ module Puppet::Parser::Functions
   newfunction(:policy_engine_test_config, :type => :rvalue) do |args|
     interpreter, output_format, expected_output, expected_exit_code, tags, metadata_file, payload_file = args
 
-    
+
     cfg = {:interpreter => interpreter,
      :expected_output => expected_output,
      :output_format => output_format,
@@ -13,7 +13,7 @@ module Puppet::Parser::Functions
      :payload_file => payload_file,
     }
 
-    if expected_exit_code =~ /^[0-9]+/
+    if expected_exit_code.is_a? Integer
       cfg[:expected_exit_code] = Integer(expected_exit_code)
       cfg.delete(:expected_output)
     elsif expected_exit_code.is_a?(Array)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class policy_engine (
-  $test_dir = "${::puppet_vardir}/policy_tests",
+  String $test_dir = "${::puppet_vardir}/policy_tests",
 ) {
 
   file { $::policy_engine_config_dir:

--- a/manifests/test.pp
+++ b/manifests/test.pp
@@ -1,11 +1,11 @@
 define policy_engine::test(
-  $ensure = present,
-  $source = undef,
-  $script = undef,
-  $interpreter = '/bin/sh',
-  $output_format = 'string',
-  $expected_output = undef,
-  $expected_exit_code = undef,
+  Enum['present','absent'] $ensure = present,
+  Variant[String,Undef] $source = undef,
+  Variant[String,Undef] $script = undef,
+  String $interpreter = '/bin/sh',
+  Enum['string','json','yaml'] $output_format = 'string',
+  Variant[String,Hash,Array,Undef] $expected_output = undef,
+  Variant[Integer,Array[Integer],Undef] $expected_exit_code = undef,
   $tags = [],
 ) {
 


### PR DESCRIPTION
This PR updates the acceptance tests, Puppet manifests, Facter fact, and parser functions to support Puppet 4.